### PR TITLE
Alembic

### DIFF
--- a/Backend/alembic.ini
+++ b/Backend/alembic.ini
@@ -1,0 +1,75 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat alembic/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = postgresql://app:1234@localhost:5432/buitre
+#driver://user:pass@localhost/dbname
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/Backend/alembic/README
+++ b/Backend/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/Backend/alembic/env.py
+++ b/Backend/alembic/env.py
@@ -1,0 +1,85 @@
+from __future__ import with_statement
+
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# If this file is executed as script (when $ alembic revision --autogenerate -m ...)
+# Use the relative path
+if __name__ == '__main__' and __package__ is None:
+    import sys
+    from os import path
+    sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+    from src.entities.user import User
+
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = User.metadada
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/Backend/alembic/env.py
+++ b/Backend/alembic/env.py
@@ -7,14 +7,6 @@ from sqlalchemy import pool
 
 from alembic import context
 
-# If this file is executed as script (when $ alembic revision --autogenerate -m ...)
-# Use the relative path
-if __name__ == '__main__' and __package__ is None:
-    import sys
-    from os import path
-    sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
-    from src.entities.user import User
-
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -28,7 +20,7 @@ fileConfig(config.config_file_name)
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-target_metadata = User.metadada
+target_metadata = None
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/Backend/alembic/script.py.mako
+++ b/Backend/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/Backend/alembic/versions/47ef3050097f_initial_schema.py
+++ b/Backend/alembic/versions/47ef3050097f_initial_schema.py
@@ -71,15 +71,15 @@ def upgrade():
     	sa.Column('created_at', sa.DateTime),
     	sa.Column('updated_at', sa.DateTime),
     	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("start_time", sa.Time, nullable=False)
-    	sa.Column("end_time", sa.Time, nullable=False)
-    	sa.Column("monday", sa.Boolean)
-    	sa.Column("tuesday", sa.Boolean)
-    	sa.Column("wednesday", sa.Boolean)
-    	sa.Column("thursday", sa.Boolean)
-    	sa.Column("friday", sa.Boolean)
-    	sa.Column("saturday", sa.Boolean)
-    	sa.Column("sunday", sa.Boolean)
+    	sa.Column("start_time", sa.Time, nullable=False),
+    	sa.Column("end_time", sa.Time, nullable=False),
+    	sa.Column("monday", sa.Boolean),
+    	sa.Column("tuesday", sa.Boolean),
+    	sa.Column("wednesday", sa.Boolean),
+    	sa.Column("thursday", sa.Boolean),
+    	sa.Column("friday", sa.Boolean),
+    	sa.Column("saturday", sa.Boolean),
+    	sa.Column("sunday", sa.Boolean),
     	sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False)
     )
 
@@ -89,7 +89,7 @@ def upgrade():
     	sa.Column('created_at', sa.DateTime),
     	sa.Column('updated_at', sa.DateTime),
     	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False, primary_key=True)
+    	sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False, primary_key=True),
     	sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False, primary_key=True)
     )
 
@@ -99,7 +99,7 @@ def upgrade():
     	sa.Column('created_at', sa.DateTime),
     	sa.Column('updated_at', sa.DateTime),
     	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False)
+    	sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False),
     	sa.Column('path', sa.String)
     )
 
@@ -109,7 +109,7 @@ def upgrade():
     	sa.Column('created_at', sa.DateTime),
     	sa.Column('updated_at', sa.DateTime),
     	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("name", sa.String)
+    	sa.Column("name", sa.String),
     	sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'))
     )
 
@@ -119,28 +119,32 @@ def upgrade():
     	sa.Column('created_at', sa.DateTime),
     	sa.Column('updated_at', sa.DateTime),
     	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("name", String)
-    	sa.Column("email" String)
-    	sa.Column('password', String)
-    	sa.Column('latitude', sa.Numeric(9, 6))
-    	sa.Column('longitude', sa.Numeric(9, 6))
-    	sa.Column('radius', sa.Integer)
-    	sa.Column('is_valid', sa.Boolean)
+    	sa.Column("name", String),
+    	sa.Column("email", String),
+    	sa.Column('password', String),
+    	sa.Column('latitude', sa.Numeric(9, 6)),
+    	sa.Column('longitude', sa.Numeric(9, 6)),
+    	sa.Column('radius', sa.Integer),
+    	sa.Column('is_valid', sa.Boolean),
     	sa.Column('score', sa.Integer)
     )
 
     op.create_table(
-    	'User',
+    	'UserTag',
     	sa.Column('id', sa.Integer, primary_key=True),
     	sa.Column('created_at', sa.DateTime),
     	sa.Column('updated_at', sa.DateTime),
     	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False)
+    	sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False),
 		sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False)
     )
 
 
 def downgrade():
+	op.drop_table('UserTag')
+	op.drop_table('User')
+	op.drop_table('Tag')
+	op.drop_table('Picture')
 	op.drop_table('OpportunityTag')
 	op.drop_table('OpportunitySchedule')
 	op.drop_table('OpportunityLike')

--- a/Backend/alembic/versions/47ef3050097f_initial_schema.py
+++ b/Backend/alembic/versions/47ef3050097f_initial_schema.py
@@ -18,136 +18,136 @@ depends_on = None
 
 def upgrade():
     op.create_table(
-    	'Comment',
-    	sa.Column('id', sa.Integer, primary_key=True),
-    	sa.Column('created_at', sa.DateTime),
-    	sa.Column('updated_at', sa.DateTime),
-    	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column('opportunity_id', sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False),
-    	sa.Column('user_id', sa.Integer, sa.ForeignKey('User.id'), nullable=False),
-    	sa.Column('score', sa.Numeric)  # Score of the comment
+        'User',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created_at', sa.DateTime),
+        sa.Column('updated_at', sa.DateTime),
+        sa.Column('last_updated_by', sa.String(16)),
+        sa.Column("name", sa.String),
+        sa.Column("email", sa.String),
+        sa.Column('password', sa.String),
+        sa.Column('latitude', sa.Numeric(9, 6)),
+        sa.Column('longitude', sa.Numeric(9, 6)),
+        sa.Column('radius', sa.Integer),
+        sa.Column('is_valid', sa.Boolean),
+        sa.Column('score', sa.Integer)
     )
 
     op.create_table(
-    	'CommentLike',
-    	sa.Column('id', sa.Integer, primary_key=True),
-    	sa.Column('created_at', sa.DateTime),
-    	sa.Column('updated_at', sa.DateTime),
-    	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column('comment_id', sa.Integer, sa.ForeignKey('Comment.id'), nullable=False),
-    	sa.Column('user_id', sa.Integer, sa.ForeignKey('User.id'), nullable=False),
-    	sa.Column('score', sa.Numeric)  # Thumbs up / down ??
+        'Opportunity',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created_at', sa.DateTime),
+        sa.Column('updated_at', sa.DateTime),
+        sa.Column('last_updated_by', sa.String(16)),
+        sa.Column("name", sa.String),
+        sa.Column("description", sa.String),
+        sa.Column("latitude", sa.Numeric(9, 6)),
+        sa.Column("longitude", sa.Numeric(9, 6)),
+        sa.Column("score", sa.Numeric),
+        sa.Column("closing_date", sa.Date),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey('User.id'), nullable=False),
     )
 
     op.create_table(
-    	'Opportunity',
-    	sa.Column('id', sa.Integer, primary_key=True),
-    	sa.Column('created_at', sa.DateTime),
-    	sa.Column('updated_at', sa.DateTime),
-    	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("name", sa.String),
-    	sa.Column("description", sa.String),
-    	sa.Column("latitude", sa.Numeric(9, 6)),
-    	sa.Column("longitude", sa.Numeric(9, 6)),
-    	sa.Column("score", sa.Numeric),
-    	sa.Column("closing_date", sa.Date),
-    	sa.Column("user_id", sa.Integer, sa.ForeignKey('User.id'), nullable=False),
+        'Tag',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created_at', sa.DateTime),
+        sa.Column('updated_at', sa.DateTime),
+        sa.Column('last_updated_by', sa.String(16)),
+        sa.Column("name", sa.String),
+        sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'))
     )
 
     op.create_table(
-    	'OpportunityLike',
-    	sa.Column('id', sa.Integer, primary_key=True),
-    	sa.Column('created_at', sa.DateTime),
-    	sa.Column('updated_at', sa.DateTime),
-    	sa.Column('last_updated_by', sa.String(16)),
-		sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False),
-    	sa.Column("user_id", sa.Integer, sa.ForeignKey('User.id'), nullable=False),
-    	sa.Column("score", sa.Integer)  # ??
+        'Comment',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created_at', sa.DateTime),
+        sa.Column('updated_at', sa.DateTime),
+        sa.Column('last_updated_by', sa.String(16)),
+        sa.Column('opportunity_id', sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False),
+        sa.Column('user_id', sa.Integer, sa.ForeignKey('User.id'), nullable=False),
+        sa.Column('score', sa.Numeric)  # Score of the comment
     )
 
     op.create_table(
-    	'OpportunitySchedule',
-    	sa.Column('id', sa.Integer, primary_key=True),
-    	sa.Column('created_at', sa.DateTime),
-    	sa.Column('updated_at', sa.DateTime),
-    	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("start_time", sa.Time, nullable=False),
-    	sa.Column("end_time", sa.Time, nullable=False),
-    	sa.Column("monday", sa.Boolean),
-    	sa.Column("tuesday", sa.Boolean),
-    	sa.Column("wednesday", sa.Boolean),
-    	sa.Column("thursday", sa.Boolean),
-    	sa.Column("friday", sa.Boolean),
-    	sa.Column("saturday", sa.Boolean),
-    	sa.Column("sunday", sa.Boolean),
-    	sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False)
+        'CommentLike',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created_at', sa.DateTime),
+        sa.Column('updated_at', sa.DateTime),
+        sa.Column('last_updated_by', sa.String(16)),
+        sa.Column('comment_id', sa.Integer, sa.ForeignKey('Comment.id'), nullable=False),
+        sa.Column('user_id', sa.Integer, sa.ForeignKey('User.id'), nullable=False),
+        sa.Column('score', sa.Numeric)  # Thumbs up / down ??
     )
 
     op.create_table(
-    	'OpportunityTag',
-    	sa.Column('id', sa.Integer, primary_key=True),
-    	sa.Column('created_at', sa.DateTime),
-    	sa.Column('updated_at', sa.DateTime),
-    	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False, primary_key=True),
-    	sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False, primary_key=True)
+        'OpportunityLike',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created_at', sa.DateTime),
+        sa.Column('updated_at', sa.DateTime),
+        sa.Column('last_updated_by', sa.String(16)),
+                sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey('User.id'), nullable=False),
+        sa.Column("score", sa.Integer)  # ??
     )
 
     op.create_table(
-    	'Picture',
-    	sa.Column('id', sa.Integer, primary_key=True),
-    	sa.Column('created_at', sa.DateTime),
-    	sa.Column('updated_at', sa.DateTime),
-    	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False),
-    	sa.Column('path', sa.String)
+        'OpportunitySchedule',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created_at', sa.DateTime),
+        sa.Column('updated_at', sa.DateTime),
+        sa.Column('last_updated_by', sa.String(16)),
+        sa.Column("start_time", sa.Time, nullable=False),
+        sa.Column("end_time", sa.Time, nullable=False),
+        sa.Column("monday", sa.Boolean),
+        sa.Column("tuesday", sa.Boolean),
+        sa.Column("wednesday", sa.Boolean),
+        sa.Column("thursday", sa.Boolean),
+        sa.Column("friday", sa.Boolean),
+        sa.Column("saturday", sa.Boolean),
+        sa.Column("sunday", sa.Boolean),
+        sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False)
     )
 
     op.create_table(
-    	'Tag',
-    	sa.Column('id', sa.Integer, primary_key=True),
-    	sa.Column('created_at', sa.DateTime),
-    	sa.Column('updated_at', sa.DateTime),
-    	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("name", sa.String),
-    	sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'))
+        'OpportunityTag',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created_at', sa.DateTime),
+        sa.Column('updated_at', sa.DateTime),
+        sa.Column('last_updated_by', sa.String(16)),
+        sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False, primary_key=True),
+        sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False, primary_key=True)
     )
 
     op.create_table(
-    	'User',
-    	sa.Column('id', sa.Integer, primary_key=True),
-    	sa.Column('created_at', sa.DateTime),
-    	sa.Column('updated_at', sa.DateTime),
-    	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("name", String),
-    	sa.Column("email", String),
-    	sa.Column('password', String),
-    	sa.Column('latitude', sa.Numeric(9, 6)),
-    	sa.Column('longitude', sa.Numeric(9, 6)),
-    	sa.Column('radius', sa.Integer),
-    	sa.Column('is_valid', sa.Boolean),
-    	sa.Column('score', sa.Integer)
+        'Picture',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created_at', sa.DateTime),
+        sa.Column('updated_at', sa.DateTime),
+        sa.Column('last_updated_by', sa.String(16)),
+        sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False),
+        sa.Column('path', sa.String)
     )
 
     op.create_table(
-    	'UserTag',
-    	sa.Column('id', sa.Integer, primary_key=True),
-    	sa.Column('created_at', sa.DateTime),
-    	sa.Column('updated_at', sa.DateTime),
-    	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False),
-		sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False)
+        'UserTag',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created_at', sa.DateTime),
+        sa.Column('updated_at', sa.DateTime),
+        sa.Column('last_updated_by', sa.String(16)),
+        sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False),
+                sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False)
     )
 
 
 def downgrade():
-	op.drop_table('UserTag')
-	op.drop_table('User')
-	op.drop_table('Tag')
-	op.drop_table('Picture')
-	op.drop_table('OpportunityTag')
-	op.drop_table('OpportunitySchedule')
-	op.drop_table('OpportunityLike')
-	op.drop_table('Opportunity')
-	op.drop_table('CommentLike')
+    op.drop_table('UserTag')
+    op.drop_table('Picture')
+    op.drop_table('OpportunityTag')
+    op.drop_table('OpportunitySchedule')
+    op.drop_table('OpportunityLike')
+    op.drop_table('CommentLike')
     op.drop_table('Comment')
+    op.drop_table('Tag')
+    op.drop_table('Opportunity')
+    op.drop_table('User')

--- a/Backend/alembic/versions/47ef3050097f_initial_schema.py
+++ b/Backend/alembic/versions/47ef3050097f_initial_schema.py
@@ -62,7 +62,7 @@ def upgrade():
     	sa.Column('last_updated_by', sa.String(16)),
 		sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False),
     	sa.Column("user_id", sa.Integer, sa.ForeignKey('User.id'), nullable=False),
-    	sa.Column("score", sa.Integer)
+    	sa.Column("score", sa.Integer)  # ??
     )
 
     op.create_table(
@@ -89,8 +89,54 @@ def upgrade():
     	sa.Column('created_at', sa.DateTime),
     	sa.Column('updated_at', sa.DateTime),
     	sa.Column('last_updated_by', sa.String(16)),
-    	sa.Column("oportunity_id", sa.Integer, sa.ForeignKey('Oportunity.id'), nullable=False, primary_key=True)
+    	sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False, primary_key=True)
     	sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False, primary_key=True)
+    )
+
+    op.create_table(
+    	'Picture',
+    	sa.Column('id', sa.Integer, primary_key=True),
+    	sa.Column('created_at', sa.DateTime),
+    	sa.Column('updated_at', sa.DateTime),
+    	sa.Column('last_updated_by', sa.String(16)),
+    	sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False)
+    	sa.Column('path', sa.String)
+    )
+
+    op.create_table(
+    	'Tag',
+    	sa.Column('id', sa.Integer, primary_key=True),
+    	sa.Column('created_at', sa.DateTime),
+    	sa.Column('updated_at', sa.DateTime),
+    	sa.Column('last_updated_by', sa.String(16)),
+    	sa.Column("name", sa.String)
+    	sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'))
+    )
+
+    op.create_table(
+    	'User',
+    	sa.Column('id', sa.Integer, primary_key=True),
+    	sa.Column('created_at', sa.DateTime),
+    	sa.Column('updated_at', sa.DateTime),
+    	sa.Column('last_updated_by', sa.String(16)),
+    	sa.Column("name", String)
+    	sa.Column("email" String)
+    	sa.Column('password', String)
+    	sa.Column('latitude', sa.Numeric(9, 6))
+    	sa.Column('longitude', sa.Numeric(9, 6))
+    	sa.Column('radius', sa.Integer)
+    	sa.Column('is_valid', sa.Boolean)
+    	sa.Column('score', sa.Integer)
+    )
+
+    op.create_table(
+    	'User',
+    	sa.Column('id', sa.Integer, primary_key=True),
+    	sa.Column('created_at', sa.DateTime),
+    	sa.Column('updated_at', sa.DateTime),
+    	sa.Column('last_updated_by', sa.String(16)),
+    	sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False)
+		sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False)
     )
 
 

--- a/Backend/alembic/versions/47ef3050097f_initial_schema.py
+++ b/Backend/alembic/versions/47ef3050097f_initial_schema.py
@@ -1,0 +1,103 @@
+"""Initial schema
+
+Revision ID: 47ef3050097f
+Revises:
+Create Date: 2019-02-13 20:36:28.176958
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '47ef3050097f'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+    	'Comment',
+    	sa.Column('id', sa.Integer, primary_key=True),
+    	sa.Column('created_at', sa.DateTime),
+    	sa.Column('updated_at', sa.DateTime),
+    	sa.Column('last_updated_by', sa.String(16)),
+    	sa.Column('opportunity_id', sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False),
+    	sa.Column('user_id', sa.Integer, sa.ForeignKey('User.id'), nullable=False),
+    	sa.Column('score', sa.Numeric)  # Score of the comment
+    )
+
+    op.create_table(
+    	'CommentLike',
+    	sa.Column('id', sa.Integer, primary_key=True),
+    	sa.Column('created_at', sa.DateTime),
+    	sa.Column('updated_at', sa.DateTime),
+    	sa.Column('last_updated_by', sa.String(16)),
+    	sa.Column('comment_id', sa.Integer, sa.ForeignKey('Comment.id'), nullable=False),
+    	sa.Column('user_id', sa.Integer, sa.ForeignKey('User.id'), nullable=False),
+    	sa.Column('score', sa.Numeric)  # Thumbs up / down ??
+    )
+
+    op.create_table(
+    	'Opportunity',
+    	sa.Column('id', sa.Integer, primary_key=True),
+    	sa.Column('created_at', sa.DateTime),
+    	sa.Column('updated_at', sa.DateTime),
+    	sa.Column('last_updated_by', sa.String(16)),
+    	sa.Column("name", sa.String),
+    	sa.Column("description", sa.String),
+    	sa.Column("latitude", sa.Numeric(9, 6)),
+    	sa.Column("longitude", sa.Numeric(9, 6)),
+    	sa.Column("score", sa.Numeric),
+    	sa.Column("closing_date", sa.Date),
+    	sa.Column("user_id", sa.Integer, sa.ForeignKey('User.id'), nullable=False),
+    )
+
+    op.create_table(
+    	'OpportunityLike',
+    	sa.Column('id', sa.Integer, primary_key=True),
+    	sa.Column('created_at', sa.DateTime),
+    	sa.Column('updated_at', sa.DateTime),
+    	sa.Column('last_updated_by', sa.String(16)),
+		sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False),
+    	sa.Column("user_id", sa.Integer, sa.ForeignKey('User.id'), nullable=False),
+    	sa.Column("score", sa.Integer)
+    )
+
+    op.create_table(
+    	'OpportunitySchedule',
+    	sa.Column('id', sa.Integer, primary_key=True),
+    	sa.Column('created_at', sa.DateTime),
+    	sa.Column('updated_at', sa.DateTime),
+    	sa.Column('last_updated_by', sa.String(16)),
+    	sa.Column("start_time", sa.Time, nullable=False)
+    	sa.Column("end_time", sa.Time, nullable=False)
+    	sa.Column("monday", sa.Boolean)
+    	sa.Column("tuesday", sa.Boolean)
+    	sa.Column("wednesday", sa.Boolean)
+    	sa.Column("thursday", sa.Boolean)
+    	sa.Column("friday", sa.Boolean)
+    	sa.Column("saturday", sa.Boolean)
+    	sa.Column("sunday", sa.Boolean)
+    	sa.Column("opportunity_id", sa.Integer, sa.ForeignKey('Opportunity.id'), nullable=False)
+    )
+
+    op.create_table(
+    	'OpportunityTag',
+    	sa.Column('id', sa.Integer, primary_key=True),
+    	sa.Column('created_at', sa.DateTime),
+    	sa.Column('updated_at', sa.DateTime),
+    	sa.Column('last_updated_by', sa.String(16)),
+    	sa.Column("oportunity_id", sa.Integer, sa.ForeignKey('Oportunity.id'), nullable=False, primary_key=True)
+    	sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False, primary_key=True)
+    )
+
+
+def downgrade():
+	op.drop_table('OpportunityTag')
+	op.drop_table('OpportunitySchedule')
+	op.drop_table('OpportunityLike')
+	op.drop_table('Opportunity')
+	op.drop_table('CommentLike')
+    op.drop_table('Comment')


### PR DESCRIPTION
Afegits fitxers d'alembic (gestor de migracions de sqlalchemy). 

Com que la versió d'autogenerar les migracions (que detecti canvis a la bbdd fets per sqlalchemy) no he aconseguit que funcionàs, he escrit un fitxer de migració inicial amb l'estructura actual de tot el model de dades.

A cada taula creada amb la migració li he definit tots els camps que finalment tendrà (els definits en el seu model + els de entity)

Per provar-ho, lo més senzill és que petis la base de dades local i la tornis a crear buida. També hauràs d'instal·lar alembic (`pip install alembic`).

Una vegada fet això moute al directori `/Backend` i executa `alembic upgrade head` i t'hauría de generar totes les taules. 

NOTA: aquesta base de dades no es correspon amb el model de dades de `master`. Estic preparant una altra branca on actualitzaré els models (a més falta mesclar la branca `oportunity_schedule_model` de la PR#3 )