### PR TITLE
Initial schema definition corrected: added user_id to UserTag and text to Comment

### DIFF
--- a/alembic/versions/47ef3050097f_initial_schema.py
+++ b/alembic/versions/47ef3050097f_initial_schema.py
@@ -61,6 +61,7 @@ def upgrade():
     op.create_table(
         'Comment',
         sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('text', sa.Text),
         sa.Column('created_at', sa.DateTime),
         sa.Column('updated_at', sa.DateTime),
         sa.Column('last_updated_by', sa.String(16)),
@@ -136,7 +137,7 @@ def upgrade():
         sa.Column('updated_at', sa.DateTime),
         sa.Column('last_updated_by', sa.String(16)),
         sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False),
-                sa.Column("tag_id", sa.Integer, sa.ForeignKey('Tag.id'), nullable=False)
+        sa.Column("user_id", sa.Integer, sa.ForeignKey('User.id'), nullable=False)
     )
 
 


### PR DESCRIPTION
A sa definició inicial de s'esquema (primera migració alembic) faltaven aquests camps :/

Hauràs de petar sa base de dades, tornarla a crear i córrer de nou ses migracions