### PR TITLE
Gunicorn fix

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn buitre:app
+web: gunicorn -b :$PORT buitre:app

--- a/app/config.py
+++ b/app/config.py
@@ -8,4 +8,3 @@ class Config(object):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     LOGIN_TOKEN_EXPIRATION = 86400  # 1 day
     VALIDATION_TOKEN_EXPIRATION = 604800  # 1 week
-    SERVER_NAME = os.environ.get('SERVER_NAME') or 'localhost:5000'


### PR DESCRIPTION
arregla es pete de gunicorn a heroku llevant es camp `SERVER_NAME` de `config.py`, que per lo vist a gunicorn no lo agrada because of reasons.