### PR TITLE
Fixtures tests

### DIFF
--- a/tests/services/test_createUserService.py
+++ b/tests/services/test_createUserService.py
@@ -4,99 +4,51 @@ from ...app.services.user.createUserService import CreateUserService
 from ...app.utils.exceptions import ArgumentException, EmailInUseException
 
 
-def test_emailless_call_raises_exception():
-    with pytest.raises(ArgumentException):
-        service = CreateUserService(
-            user_repository=None,
-            user_factory=None,
-            password_hasher=None,
-            validation_token_generator=None,
-            email_factory=None,
-            email_sender=None
-        )
-        service.call({'name': 'andreu', 'password': 'password123'})
+class fakeRepo:
+    @staticmethod
+    def get_by_email(email):
+        if email == "existing@buitre.com":
+            return "not None value"
+        return None
+
+    @staticmethod
+    def persist(user):
+        return user
 
 
-def test_nameless_call_raises_exception():
-    with pytest.raises(ArgumentException):
-        service = CreateUserService(
-            user_repository=None,
-            user_factory=None,
-            password_hasher=None,
-            validation_token_generator=None,
-            email_factory=None,
-            email_sender=None
-        )
-        service.call({'email': 'aramos@buitre.com', 'password': 'password123'})
+class fakeFactory:
+    @staticmethod
+    def create(name, email, password):
+        dummyuser = mock.Mock()
+        dummyuser.name = name
+        dummyuser.email = email
+        dummyuser.password = password
+        dummyuser.validation_token = None
+        return dummyuser
 
 
-def test_passwordless_call_raises_exception():
-    with pytest.raises(ArgumentException):
-        service = CreateUserService(
-            user_repository=None,
-            user_factory=None,
-            password_hasher=None,
-            validation_token_generator=None,
-            email_factory=None,
-            email_sender=None
-        )
-        service.call({'email': 'aramos@buitre.com', 'name': 'andreu'})
+class fakeEmailFactory:
+    @staticmethod
+    def create_user_validation_email(name, email, validation_token):
+        return object()
 
 
-def test_already_existing_email_check():
-    with pytest.raises(EmailInUseException):
-        class FakeRepo:
-            @staticmethod
-            def get_by_email(email):
-                return "not None value"
-
-        service = CreateUserService(
-            user_repository=FakeRepo,
-            user_factory=None,
-            password_hasher=None,
-            validation_token_generator=None,
-            email_factory=None,
-            email_sender=None
-        )
-        service.call({'email': 'aramos@buitre.com', 'password': 'pwd123', 'name': 'Andreu'})
+class fakeEmailSender:
+    @staticmethod
+    def send(email):
+        pass
 
 
-def test_password_is_hashed():
-    class fakeRepo:
-        @staticmethod
-        def get_by_email(email):
-            return None
+def dummyHash(password):
+    return 'hashed' + password
 
-        @staticmethod
-        def persist(user):
-            return user
 
-    class fakeFactory:
-        @staticmethod
-        def create(name, email, password):
-            dummyuser = mock.Mock()
-            dummyuser.name = name
-            dummyuser.email = email
-            dummyuser.password = password
-            dummyuser.validation_token = None
-            return dummyuser
+def generateDummyToken(email):
+    return "dummytoken"
 
-    class fakeEmailFactory:
-        @staticmethod
-        def create_user_validation_email(name, email, validation_token):
-            return object()
 
-    class fakeEmailSender:
-        @staticmethod
-        def send(email):
-            pass
-
-    def dummyHash(password):
-        return 'hashed' + password
-
-    def generateDummyToken(email):
-        return "dummytoken"
-
+@pytest.fixture(scope="module")
+def service():
     service = CreateUserService(
         user_repository=fakeRepo,
         user_factory=fakeFactory,
@@ -105,6 +57,30 @@ def test_password_is_hashed():
         email_factory=fakeEmailFactory,
         email_sender=fakeEmailSender
     )
+    return service
+
+
+# TEST CASES
+def test_emailless_call_raises_exception(service):
+    with pytest.raises(ArgumentException):
+        service.call({'name': 'andreu', 'password': 'password123'})
+
+
+def test_nameless_call_raises_exception(service):
+    with pytest.raises(ArgumentException):
+        service.call({'email': 'aramos@buitre.com', 'password': 'password123'})
+
+
+def test_passwordless_call_raises_exception(service):
+    with pytest.raises(ArgumentException):
+        service.call({'email': 'aramos@buitre.com', 'name': 'andreu'})
+
+
+def test_already_existing_email_check(service):
+    with pytest.raises(EmailInUseException):
+        service.call({'email': 'existing@buitre.com', 'password': 'pwd123', 'name': 'Andreu'})
+
+
+def test_password_is_hashed(service):
     result = service.call({'name': "Andreu", 'email': "aramos@buitre.com", 'password': "pass123"})
-    print(result)
     assert result.password == 'hashedpass123'

--- a/tests/services/test_loginUserService.py
+++ b/tests/services/test_loginUserService.py
@@ -64,6 +64,6 @@ def test_login_token():
         def generate_session_token(anything):
             return "this-is-a-token"
 
-    service = LoginUserService(fakeRepo, fakeTokenManager, password_hasher_func)
+    service = LoginUserService(fakeRepo, fakeTokenManager.generate_session_token, password_hasher_func)
     token = service.call({'email': "andre@buitre.com", 'password': "unhashed_password"})
     assert token == 'this-is-a-token'

--- a/tests/services/test_loginUserService.py
+++ b/tests/services/test_loginUserService.py
@@ -4,66 +4,60 @@ from ...app.services.user.loginUserService import LoginUserService
 from ...app.entities.user import User
 
 
-def test_email_required():
+class fakeRepo:
+    @staticmethod
+    def get_by_email(email):
+        if email == "unexisting@buitre.com":
+            return None
+        user = User('test', 'test@test.com', 'test123')
+        user.password = 'hashed_password'
+        user.is_valid = True
+        return user
+
+    @staticmethod
+    def persist(user):
+        return user
+
+
+def password_hasher_func(hashed_password, password):
+    if password == "wrong":
+        return False
+    return True
+
+
+class fakeTokenManager:
+    @staticmethod
+    def generate_session_token(anything):
+        return "this-is-a-token"
+
+
+@pytest.fixture(scope="module")
+def service():
+    service = LoginUserService(fakeRepo, fakeTokenManager.generate_session_token, password_hasher_func)
+    return service
+
+
+# TEST CASES
+def test_email_required(service):
     with pytest.raises(ArgumentException):
-        service = LoginUserService(None, None, None)
         service.call({'password': "123"})
 
 
-def test_password_required():
+def test_password_required(service):
     with pytest.raises(ArgumentException):
-        service = LoginUserService(None, None, None)
         service.call({'email': "andreu@buitre.com"})
 
 
-def test_unexisting_user():
+def test_unexisting_user(service):
     with pytest.raises(AuthenticationException):
-        class fakeRepo:
-            @staticmethod
-            def get_by_email(email):
-                return None
-
-        service = LoginUserService(fakeRepo, None, None)
-        service.call({'email': "andreu@buitre.com", 'password': "123"})
+        service.call({'email': "unexisting@buitre.com", 'password': "123"})
 
 
-def test_wrong_password():
+def test_wrong_password(service):
     with pytest.raises(AuthenticationException):
-        class fakeRepo:
-            @staticmethod
-            def get_by_email(email):
-                user = User
-                user.password = 'hashed_password'
-                return user
-
-        def password_hasher_func(hashed_password, password):
-            return False
-
-        service = LoginUserService(fakeRepo, None, password_hasher_func)
-        service.call({'email': "andre@buitre.com", 'password': "unhashed_password"})
+        service.call({'email': "andre@buitre.com", 'password': "wrong"})
 
 
-def test_login_token():
-    class fakeRepo:
-        @staticmethod
-        def get_by_email(email):
-            user = User('test', 'test@test.com', 'test123')
-            user.password = 'hashed_password'
-            user.is_valid = True
-            return user
-
-        @staticmethod
-        def persist(user):
-            return user
-
-    def password_hasher_func(hashed_password, password):
-        return True
-
-    class fakeTokenManager:
-        @staticmethod
-        def generate_session_token(anything):
-            return "this-is-a-token"
-
-    service = LoginUserService(fakeRepo, fakeTokenManager.generate_session_token, password_hasher_func)
+def test_login_token(service):
     token = service.call({'email': "andre@buitre.com", 'password': "unhashed_password"})
     assert token == 'this-is-a-token'

--- a/tests/services/test_validateUserService.py
+++ b/tests/services/test_validateUserService.py
@@ -5,80 +5,61 @@ from ...app.services.user.validateUserService import ValidateUserService
 from ...app.entities.user import User
 
 
-def test_missing_user_id():
-    with pytest.raises(ArgumentException):
-        service = ValidateUserService(
-            user_repository=None,
-            validation_token_verifier=None
-        )
+class fakeRepo:
+    @staticmethod
+    def get_by_email(email):
+        if email != "email@email.com":
+            return None
+        user = User("andreu", email, "123")
+        user.id = id
+        user.is_valid = False
+        return user
 
-        service.call({})
-
-
-def test_invalid_token():
-    with pytest.raises(UserValidationException):
-        def dummyverifier(token):
-            raise InvalidTokenException()
-
-        service = ValidateUserService(
-            validation_token_verifier=dummyverifier,
-            user_repository=None
-        )
-
-        service.call({'validation_token': "invalid_token"})
+    @staticmethod
+    def persist(user):
+        return user
 
 
-def test_expired_token():
-    with pytest.raises(UserValidationException):
-        def dummyverifier(token):
-            raise ExpiredTokenException()
-
-        service = ValidateUserService(
-            validation_token_verifier=dummyverifier,
-            user_repository=None
-        )
-
-        service.call({'validation_token': "expired_token"})
+def dummy_verifier(token):
+    if token == "invalid_token":
+        raise InvalidTokenException
+    if token == "expired_token":
+        raise ExpiredTokenException
+    if token == "unexisting_user":
+        return False
+    return "email@email.com"
 
 
-def test_unexisting_user():
-    with pytest.raises(UserValidationException):
-        class fakeRepo:
-            @staticmethod
-            def get_by_email(email):
-                None
-
-        def dummyverifier(token):
-            return "email@email.com"
-
-        service = ValidateUserService(
-            user_repository=fakeRepo,
-            validation_token_verifier=dummyverifier
-        )
-
-        service.call({'validation_token': "something"})
-
-
-def test_user_is_validated():
-    class fakeRepo:
-        @staticmethod
-        def get_by_email(email):
-            user = User("andreu", email, "123")
-            user.id = id
-            user.is_valid = False
-            return user
-
-        @staticmethod
-        def persist(user):
-            return user
-
-    def dummy_verifier(token):
-        return True
-
+@pytest.fixture(scope="module")
+def service():
     service = ValidateUserService(
         user_repository=fakeRepo,
         validation_token_verifier=dummy_verifier
     )
-    user = service.call({'validation_token': "sometoken"})
+    return service
 
+
+# TEST CASES
+def test_missing_user_id(service):
+    with pytest.raises(ArgumentException):
+        service.call({})
+
+
+def test_invalid_token(service):
+    with pytest.raises(UserValidationException):
+        service.call({'validation_token': "invalid_token"})
+
+
+def test_expired_token(service):
+    with pytest.raises(UserValidationException):
+        service.call({'validation_token': "expired_token"})
+
+
+def test_unexisting_user(service):
+    with pytest.raises(UserValidationException):
+        service.call({'validation_token': "unexisting_user"})
+
+
+def test_user_is_validated(service):
+    user = service.call({'validation_token': "sometoken"})
     assert user.is_valid


### PR DESCRIPTION
Reimplementats es tests de create, login i vaidate amb fixtures, que permeten no haver d'instanciar es servei, montat amb funcions dummy a cada test.

En es nostro cas no millora massa es codi, només mos estalviam unes quantes linies, però a mesura que volguem testejar coses més complicades, amb més test cases, mos anirà beníssim