### PR TITLE
Get user service

### DIFF
--- a/app/entities/user.py
+++ b/app/entities/user.py
@@ -6,6 +6,7 @@ from .opportunityLike import OpportunityLike
 from .userTag import UserTag
 from marshmallow import Schema, fields
 
+
 class User(Entity, Base):
     __tablename__ = 'User'
 
@@ -37,6 +38,17 @@ class User(Entity, Base):
 
     def validate(self):
         self.is_valid = True
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'email': self.email,
+            'latitude': self.latitude,
+            'longitude': self.longitude,
+            'radius': self.radius,
+            'score': self.score
+        }
 
 
 class UserSchema(Schema):

--- a/app/services/user/authenticateUserService.py
+++ b/app/services/user/authenticateUserService.py
@@ -1,0 +1,18 @@
+from ...utils.exceptions import ArgumentException
+
+
+class AuthenticateUserService():
+
+    def __init__(self, token_verifier):
+        self.verify_token = token_verifier
+
+    def call(self, args):
+        if 'token' not in args or args['token'] is None:
+            raise ArgumentException('missing token parameter')
+
+        token = args['token']
+
+        return self.verify_token(token)
+
+
+

--- a/app/services/user/getUserService.py
+++ b/app/services/user/getUserService.py
@@ -1,0 +1,20 @@
+from ...utils.exceptions import ArgumentException, UserNotFoundException
+
+
+class GetUserService():
+
+    def __init__(self, user_repository):
+        self.user_repository = user_repository
+
+    def call(self, args):
+        if 'user_id' not in args or args['user_id'] is None:
+            raise ArgumentException('missing user_id parameter')
+
+        user_id = args['user_id']
+
+        user = self.user_repository.get_by_id(user_id)
+
+        if user is None:
+            raise UserNotFoundException('user ' + str(user_id) + ' not found')
+
+        return user.to_dict()

--- a/app/utils/exceptions.py
+++ b/app/utils/exceptions.py
@@ -35,14 +35,17 @@ class ExpiredTokenException(Exception):
     def __init__(self):
         message = 'token is expired'
         super().__init__(message)
+        self.message = message
 
 
 class InvalidTokenException(Exception):
     def __init__(self):
         message = 'invalid token'
         super().__init__(message)
+        self.message = message
 
 
 class UserNotFoundException(Exception):
     def __init__(self, message):
         super().__init__(message)
+        self.message = message

--- a/app/utils/exceptions.py
+++ b/app/utils/exceptions.py
@@ -41,3 +41,8 @@ class InvalidTokenException(Exception):
     def __init__(self):
         message = 'invalid token'
         super().__init__(message)
+
+
+class UserNotFoundException(Exception):
+    def __init__(self, message):
+        super().__init__(message)

--- a/app/utils/tokenManager.py
+++ b/app/utils/tokenManager.py
@@ -1,4 +1,4 @@
-from itsdangerous import URLSafeTimedSerializer, SignatureExpired, BadTimeSignature
+from itsdangerous import URLSafeTimedSerializer, SignatureExpired, BadTimeSignature, BadSignature
 from .exceptions import ExpiredTokenException, InvalidTokenException
 from ..routes import app
 
@@ -17,7 +17,7 @@ class TokenManager:
             data = s.loads(token, max_age=app.config['LOGIN_TOKEN_EXPIRATION'])
         except SignatureExpired:
             raise ExpiredTokenException
-        except BadTimeSignature:
+        except (BadTimeSignature, BadSignature):
             raise InvalidTokenException
 
         return data

--- a/tests/services/test_authenticateUserService.py
+++ b/tests/services/test_authenticateUserService.py
@@ -1,0 +1,40 @@
+import pytest
+
+from ...app.utils.exceptions import ArgumentException, InvalidTokenException, ExpiredTokenException
+from ...app.services.user.authenticateUserService import AuthenticateUserService
+
+
+def dummy_verify_token(token):
+    if token == "invalid_token":
+        raise InvalidTokenException
+    if token == "expired_token":
+        raise ExpiredTokenException
+    return 123
+
+
+@pytest.fixture
+def service():
+    service = AuthenticateUserService(
+        token_verifier=dummy_verify_token
+    )
+    return service
+
+
+def test_tokenless_call(service):
+    with pytest.raises(ArgumentException):
+        service.call({})
+
+
+def test_invalid_token(service):
+    with pytest.raises(InvalidTokenException):
+        service.call({'token': 'invalid_token'})
+
+
+def test_expired_token(service):
+    with pytest.raises(ExpiredTokenException):
+        service.call({'token': 'expired_token'})
+
+
+def test_valid_token(service):
+    user_id = service.call({'token': 'valid_token'})
+    assert user_id == 123

--- a/tests/services/test_getUserService.py
+++ b/tests/services/test_getUserService.py
@@ -1,0 +1,39 @@
+import pytest
+
+from ...app.entities.user import User
+from ...app.services.user.getUserService import GetUserService
+from ...app.utils.exceptions import ArgumentException, UserNotFoundException
+
+
+class fakeRepo():
+    @staticmethod
+    def get_by_id(user_id):
+        if user_id == 999:
+            return None
+        user = User('andreu', 'andreu@buitre.com', '123')
+        return user
+
+
+@pytest.fixture()
+def service():
+    service = GetUserService(
+        user_repository=fakeRepo
+    )
+    return service
+
+
+def test_call_without_argument(service):
+    with pytest.raises(ArgumentException):
+        service.call({})
+
+
+def test_user_does_not_exist(service):
+    with pytest.raises(UserNotFoundException):
+        service.call({'user_id': 999})
+
+
+def test_user_data(service):
+    user = service.call({'user_id': 1})
+    assert isinstance(user, dict)
+    assert user['name'] == 'andreu'
+    assert user['email'] == 'andreu@buitre.com'


### PR DESCRIPTION
Endpoint per obtenir dades d'un usuari, d'on sa pàgina de perfil treurà ses dades.

Fixa't en com he usat es serveis, dins s'endpoint de sa API `get_user()` crid tant a nes servei d'autenticació (que retorna un user_id donat un auth token) i amb aquest crid a nes servei per treure ses dades d'un usuari. Creus que és correcte fer-ho així? O hauría de ser es propi servei d'obtenir dades `GetUserService` es qui cridàs a nes servei d'autenticació? Jo no ho tenc massa clar.

Per una part no m'agrada que per cridar es servei `GetUserService` s'hagui de fer amb un token, que és molt com a detall d'implementació (es fet de que s'autentiqui un usuari amb un token, podría ser amb usr+pwd a cada request). Per altra part tampoc m'agrada massa que un mateix endpoint de sa api faci dues coses.

Ho xerram dilluns si eso 