### PR TITLE
Afageix suport per requests json

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -106,3 +106,11 @@ def authenticate_user(f):
         return f(*args, **kwargs)
 
     return authentication_decorator
+
+
+def get_request(request):
+    if request.is_json:
+        rq = request.json
+    else:
+        rq = request.form
+    return rq

--- a/app/api/opportunity_api.py
+++ b/app/api/opportunity_api.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request, jsonify, g
 
-from ..api import GetOpportunityService, CreateOpportunityService, authenticate_user
+from ..api import GetOpportunityService, CreateOpportunityService, authenticate_user, get_request
 from ..utils.exceptions import OpportunityNotFoundException
 
 opportunity_api = Blueprint('opportunity_api', __name__)
@@ -25,19 +25,20 @@ def get_opportunity(opportunity_id):
 @opportunity_api.route('/create', methods=['POST'])
 @authenticate_user
 def create_opportunity():
+    rq = get_request(request)
     response = {}
     response_code = 200
 
-    tags = request.form.get('tags').split(',')
-    pictures = request.form.get('pictures').split(',')
+    tags = rq.get('tags').split(',')
+    pictures = rq.get('pictures').split(',')
 
     args = {
         'user_id': g.user_id,
-        'name': request.form.get('name'),
-        'description': request.form.get('description'),
-        'address': request.form.get('address'),
-        'latitude': request.form.get('latitude'),
-        'longitude': request.form.get('longitude'),
+        'name': rq.get('name'),
+        'description': rq.get('description'),
+        'address': rq.get('address'),
+        'latitude': rq.get('latitude'),
+        'longitude': rq.get('longitude'),
         'pictures': pictures,
         'tags': tags
     }

--- a/app/api/profile_api.py
+++ b/app/api/profile_api.py
@@ -1,6 +1,6 @@
 from flask import g, jsonify, Blueprint, request
 
-from ..api import authenticate_user, GetProfileService, UpdateProfileService, UpdateUserTagsService
+from ..api import authenticate_user, GetProfileService, UpdateProfileService, UpdateUserTagsService, get_request
 
 profile_api = Blueprint('profile_api', __name__)
 
@@ -34,22 +34,23 @@ def get_public_profile(id):
 @profile_api.route('/update', methods=["POST"])
 @authenticate_user
 def update_profile():
+    rq = get_request(request)
     user_id = g.user_id
 
     args = {
         'user_id': user_id
     }
 
-    if request.form.get('name'):
-        args['name'] = request.form.get('name')
-    if request.form.get('latitude'):
-        args['latitude'] = request.form.get('latitude')
-    if request.form.get('longitude'):
-        args['longitude'] = request.form.get('longitude')
-    if request.form.get('radius'):
-        args['radius'] = request.form.get('radius')
-    if request.form.get('profile_picture'):
-        args['profile_picture'] = request.form.get('profile_picture')
+    if rq.get('name'):
+        args['name'] = rq.get('name')
+    if rq.get('latitude'):
+        args['latitude'] = rq.get('latitude')
+    if rq.get('longitude'):
+        args['longitude'] = rq.get('longitude')
+    if rq.get('radius'):
+        args['radius'] = rq.get('radius')
+    if rq.get('profile_picture'):
+        args['profile_picture'] = rq.get('profile_picture')
 
     UpdateProfileService.call(args)
 
@@ -59,9 +60,10 @@ def update_profile():
 @profile_api.route('/update/tags', methods=["POST"])
 @authenticate_user
 def update_tags():
+    rq = get_request(request)
     user_id = g.user_id
 
-    tags = request.form.get('tags').split(",")
+    tags = rq.get('tags').split(",")
 
     UpdateUserTagsService.call({'user_id': user_id, 'tags': tags})
 

--- a/app/api/user_api.py
+++ b/app/api/user_api.py
@@ -3,7 +3,7 @@ from flask import Blueprint, request, jsonify, g
 from datetime import datetime, timedelta
 
 from ..api import authenticate_user, CreateUserService, ValidateUserService, LoginUserService, GetUserService, \
-    SendUserRecoveryService, RecoverUserService
+    SendUserRecoveryService, RecoverUserService, get_request
 from ..routes import app
 from ..entities.user import UserRepository
 from ..utils.exceptions import \
@@ -18,11 +18,12 @@ user_api = Blueprint('user_api', __name__)
 
 @user_api.route('/create', methods=['POST'])
 def create_user():
+    rq = get_request(request)
     response_code = 200
     result = {}
-    name = request.form.get('name')
-    email = request.form.get('email')
-    password = request.form.get('password')
+    name = rq.get('name')
+    email = rq.get('email')
+    password = rq.get('password')
 
     try:
         CreateUserService.call({
@@ -58,10 +59,12 @@ def validate_user():
 
 @user_api.route('/login', methods=['POST'])
 def login_user():
+    rq = get_request(request)
     response_code = 200
     response = {}
-    email = request.form.get('email')
-    password = request.form.get('password')
+    email = rq.get('email')
+    password = rq.get('password')
+
 
     try:
         token = LoginUserService.call({
@@ -108,9 +111,10 @@ def get_user():
 
 @user_api.route('/send_recovery', methods=['POST'])
 def send_user_recovery():
+    rq = get_request(request)
     response = {}
     response_code = 200
-    email = request.form.get('email')
+    email = rq.get('email')
 
     try:
         SendUserRecoveryService.call({


### PR DESCRIPTION
Per donar suport a requests que duguin ses dades en format `json`, a més de soportar es format form post, s'ha canviat s'accés a request, amb un mètode `get_request(request)` que decodifica ses dades que hi venguin, sigui per post o en json. 

S'ha canviat tot s'ús de request per sa variable `rq` que conté ses dades parsejades. 